### PR TITLE
added strip_ntfs option for stripping ntfs reserved characters from paths

### DIFF
--- a/config.ui
+++ b/config.ui
@@ -373,6 +373,71 @@
                 <property name="position">3</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkFrame" id="frame4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkAlignment" id="alignment4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkHBox" id="hbox6">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkCheckButton" id="ntfsbutton">
+                            <property name="label" translatable="yes">Enabled</property>
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_action_appearance">False</property>
+                            <property name="xalign">0</property>
+                            <property name="image_position">right</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkHBox" id="hbox7">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">43</property>
+                    <child>
+                      <object class="GtkLabel" id="ntfslabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Strip NTFS Chars</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="padding">5</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/fileops.py
+++ b/fileops.py
@@ -66,7 +66,7 @@ UPDATING = 'Updating Database:'
 
 class MusicFile():
     """ Class that performs all the file operations """
-    def __init__(self, fileorganizer, db_entry=None):
+    def __init__(self, fileorganizer, db_entry=None, strip_ntfs=False):
         self.conf = configparser.RawConfigParser()
         conffile = (os.getenv('HOME') + '/.local/share/rhythmbox/' +
                          'plugins/fileorganizer/fo.conf')
@@ -75,6 +75,7 @@ class MusicFile():
         self.rbdb = self.rbfo.db
         self.log = LogFile()
         self.url = UrlData()
+        self.strip_ntfs = strip_ntfs
         if db_entry:
             # Track and disc digits from gconf
             padded = '%s' % ('%0' + str(2) + '.d')
@@ -119,7 +120,7 @@ class MusicFile():
                 except:
                     print('Create folder Failed')
             artfile = '%ta - %at'
-            artfile = (tools.data_filler(self, artfile) + '.jpg')
+            artfile = (tools.data_filler(self, artfile, strip_ntfs=self.strip_ntfs) + '.jpg')
             artfile = os.getenv('HOME') + RB_COVER_CACHE + artfile
             if not os.path.isfile(artfile):
                 print('COVERART MISSING')
@@ -178,11 +179,11 @@ class MusicFile():
             return source
         # Set Destination Directory
         targetdir = '/' + self.rbfo.configurator.get_val('layout-path')
-        targetdir = tools.data_filler(self, targetdir)
+        targetdir = tools.data_filler(self, targetdir, strip_ntfs=self.strip_ntfs)
         targetdir = tools.folderize(self.rbfo.configurator, targetdir)
         # Set Destination  Filename
         targetname = self.rbfo.configurator.get_val('layout-filename')
-        targetname = tools.data_filler(self, targetname)
+        targetname = tools.data_filler(self, targetname, strip_ntfs=self.strip_ntfs)
         targetname += os.path.splitext(self.location)[1]
         # Join destination
         destin = (os.path.join(targetdir, targetname)).replace('file:///', '/')
@@ -283,7 +284,7 @@ class MusicFile():
         # Begin Log File
         currenttime = time.strftime("%I:%M:%S %p", time.localtime())
         logheader = '%ta - %at - '
-        logheader = (tools.data_filler(self, logheader) + currenttime)
+        logheader = (tools.data_filler(self, logheader, strip_ntfs=self.strip_ntfs) + currenttime)
         #self.log = LogFile()
         self.log.log_processing(logheader)
         self.log.log_processing((IN + source))

--- a/fileorganizer.py
+++ b/fileorganizer.py
@@ -111,6 +111,8 @@ class Fileorganizer(GObject.Object, Peas.Activatable, PeasGtk.Configurable):
             b.get_object("tagsbutton").set_active(True)
         if self.conf.get(c, "preview_mode") == "True":
             b.get_object("previewbutton").set_active(True)
+        if self.conf.get(c, "strip_ntfs") == "True":
+            b.get_object("ntfsbutton").set_active(True)
         window.show_all()
         return window
 
@@ -142,6 +144,10 @@ class Fileorganizer(GObject.Object, Peas.Activatable, PeasGtk.Configurable):
             self.conf.set(c, "preview_mode", "True")
         else:
             self.conf.set(c, "preview_mode", "False")
+        if builder.get_object("ntfsbutton").get_active():
+            self.conf.set(c, "strip_ntfs", "True")
+        else:
+            self.conf.set(c, "strip_ntfs", "False")
         self.conf.set(c, "log_path",
                       builder.get_object("log_path").get_text())
         self.conf.set(c, "cover_names",
@@ -166,6 +172,7 @@ class Fileorganizer(GObject.Object, Peas.Activatable, PeasGtk.Configurable):
     # Process selection: Run in Preview Mode or Normal Mode
     def process_selection(self, filelist):
         self.conf.read(self.configfile)
+        strip_ntfs = self.conf.get(c, "strip_ntfs") == "True"
         # Run in Preview Mode
         if self.conf.get(c, "preview_mode") == "True":
             if filelist != []:
@@ -176,7 +183,7 @@ class Fileorganizer(GObject.Object, Peas.Activatable, PeasGtk.Configurable):
                 FILE = open(damlist, "w")
                 FILE.close()
                 for item in filelist:
-                    item = fileops.MusicFile(self, item)
+                    item = fileops.MusicFile(self, item, strip_ntfs=strip_ntfs)
                     item.preview()
                 Notify.init('Fileorganizer')
                 title = 'Fileorganizer'
@@ -187,7 +194,7 @@ class Fileorganizer(GObject.Object, Peas.Activatable, PeasGtk.Configurable):
                 self.results(prelist, damlist)
         else:
             # Run Normally
-            self.organize(filelist)
+            self.organize(filelist, strip_ntfs)
             Notify.init('Fileorganizer')
             title = 'Fileorganizer'
             note = 'Your selection is organised'
@@ -201,10 +208,10 @@ class Fileorganizer(GObject.Object, Peas.Activatable, PeasGtk.Configurable):
             os.system('/usr/bin/xdg-open ' + damlist)
 
     # Organize array of files
-    def organize(self, filelist):
+    def organize(self, filelist, strip_ntfs=False):
         if filelist != []:
             for item in filelist:
-                item = fileops.MusicFile(self, item)
+                item = fileops.MusicFile(self, item, strip_ntfs=strip_ntfs)
                 item.relocate()
 
 

--- a/template/fo.conf
+++ b/template/fo.conf
@@ -7,4 +7,5 @@ log_path = .fileorganizer.log
 log_enabled = True
 preview_mode = False
 update_tags = True
+strip_ntfs = False
 

--- a/tools.py
+++ b/tools.py
@@ -26,7 +26,7 @@ def folderize(configurator, folder):
 
 
 # Replace the placeholders with the correct values
-def data_filler(files, string):
+def data_filler(files, string, strip_ntfs=False):
     """ replace string data with metadata from current item """
     string = str(string)
     for key in fileops.RB_METATYPES:
@@ -35,20 +35,24 @@ def data_filler(files, string):
                 artisttest = files.get_metadata('aa')
                 if artisttest == '':
                     string = string.replace(('%' + key),
-                                            process(files.get_metadata('ta')))
+                                            process(files.get_metadata('ta'), strip_ntfs))
                     print(string + ' ALBUM ARTIST NOT FOUND')
                 else:
                     string = string.replace(('%' + key),
-                                            process(files.get_metadata(key)))
+                                            process(files.get_metadata(key), strip_ntfs))
                     print(string + ' ALBUM ARTIST FOUND')
             else:
                 string = string.replace(('%' + key),
-                                        process(files.get_metadata(key)))
+                                        process(files.get_metadata(key), strip_ntfs))
     return string
 
 
 # Process names and replace any undesired characters
-def process(string):
+def process(string, strip_ntfs=False):
     """ Prevent / character to avoid creating folders """
     string = string.replace('/', '_')  # if present
+    if strip_ntfs:
+        string = ''.join(c for c in string if c not in '<>:"\\|?*')
+        while string.endswith('.'):
+            string = string[:-1]
     return string


### PR DESCRIPTION
My music library is located on an NTFS drive which doesn't allow [reserved characters](https://msdn.microsoft.com/en-us/library/aa365247) in file names/paths. I've added a new option in the plugin's preferences which, when enabled, strips these characters from the output path/file for safe use in NTFS.

IMHO, I think this should be the default behavior regardless of the filesystem type.