### PR TITLE
Support multiple library locations

### DIFF
--- a/fileops.py
+++ b/fileops.py
@@ -194,7 +194,7 @@ class MusicFile(object):
         targetdir = '/' + self.rbfo.configurator.get_val('layout-path')
         targetdir = tools.data_filler(self, targetdir,
                                       strip_ntfs=self.strip_ntfs)
-        targetloc = self.rbfo.configurator.get_val('locations')[0]
+        targetloc = tools.library_location(self, self.rbfo.configurator.get_val('locations'))
         targetpath = url2pathname(targetloc).replace('file:///', '/')
         targetdir = tools.folderize(targetpath, targetdir)
         # Set Destination  Filename

--- a/fileops.py
+++ b/fileops.py
@@ -253,8 +253,9 @@ class MusicFile(object):
         else:
             if os.path.isfile(destin):
                 # Copy the existing file to a backup dir
-                backupdir = (((self.rbfo.configurator.get_val('locations'))[0]
-                              + '/backup/').replace('file:///', '/'))
+                backuploc = tools.library_location(self, self.rbfo.configurator.get_val('locations'))
+                backupdir = (url2pathname(backuploc)
+                              + '/backup/').replace('file:///', '/')
                 backup = os.path.join(backupdir, os.path.basename(destin))
                 if os.path.isfile(backup):
                     counter = 0

--- a/fileorganizer.py
+++ b/fileorganizer.py
@@ -42,6 +42,8 @@ class Fileorganizer(GObject.Object, Peas.Activatable, PeasGtk.Configurable):
     """ Main class that loads fileorganizer into Rhythmbox """
     __gtype_name = 'fileorganizer'
     object = GObject.property(type=GObject.Object)
+    _menu_names = ['browser-popup',
+                  'playlist-popup']
     def __init__(self):
         GObject.Object.__init__(self)
         self.configurator = FileorganizerConf()
@@ -70,9 +72,9 @@ class Fileorganizer(GObject.Object, Peas.Activatable, PeasGtk.Configurable):
     def do_deactivate(self):
         """ Deactivate the plugin """
         print("deactivating Fileorganizer")
-        Gio.Application.get_default().remove_plugin_menu_item('browser-popup',
-                                                              'selection-' +
-                                                              'organize')
+        app = Gio.Application.get_default()
+        for menu_name in Fileorganizer._menu_names:
+            app.remove_plugin_menu_item(menu_name, 'selection-' + 'organize')
         self.action_group = None
         self.action = None
         #self.source.delete_thyself()
@@ -105,7 +107,8 @@ class Fileorganizer(GObject.Object, Peas.Activatable, PeasGtk.Configurable):
         item.set_detailed_action("app.organize-selection")
 
         # add plugin menu item
-        app.add_plugin_menu_item('browser-popup', "Organize Selection", item)
+        for menu_name in Fileorganizer._menu_names:
+            app.add_plugin_menu_item(menu_name, "Organize Selection", item)
         app.add_action(action)
 
     # Create the Configure window in the rhythmbox plugins menu

--- a/logops.py
+++ b/logops.py
@@ -32,7 +32,7 @@ class LogFile(object):
         # Log if Enabled
         if log_enabled == 'True':
             # Create if missing
-            if not (os.path.exists(log_filename) or
+            if (not os.path.exists(log_filename) or
                     os.path.getsize(log_filename) >= 1076072):
                 files = codecs.open(log_filename, "w", "utf8")
                 files.close()

--- a/tools.py
+++ b/tools.py
@@ -17,6 +17,16 @@ import subprocess
 import fileops
 
 
+# Returns the library location for a file,
+# or the default location if the file is not inside any library location
+# Throws an error if there are no file:// locations in the library
+def library_location(files, library_locations):
+    file_locations = list(l for l in library_locations if l.startswith('file://'))
+    # TODO file_locations could be empty - if so, throw error here
+    return next((l for l in file_locations if files.location.startswith(l)),
+                file_locations[0])
+
+
 # Create a folder inside a library path if non-existant, and return it
 def folderize(library_path, folder):
     """ Create folders for file operations """

--- a/tools.py
+++ b/tools.py
@@ -17,12 +17,17 @@ import subprocess
 import fileops
 
 
+class LibraryLocationError(Exception):
+    """To be raised when a file:// library location could not be found"""
+
+
 # Returns the library location for a file,
 # or the default location if the file is not inside any library location
-# Throws an error if there are no file:// locations in the library
+# Raises an error if there are no file:// locations in the library
 def library_location(files, library_locations):
     file_locations = list(l for l in library_locations if l.startswith('file://'))
-    # TODO file_locations could be empty - if so, throw error here
+    if not file_locations:
+        raise LibraryLocationError('No file:// locations could be found in the library')
     return next((l for l in file_locations if files.location.startswith(l)),
                 file_locations[0])
 


### PR DESCRIPTION
Try and define sensible behaviour when there are multiple library locations configured:

1. When a file to organize is already inside a particular library location, keep the file inside that location instead of relocating to the default (first) library location
2. Same behaviour as above when making a backup copy
3. Raise an error if there are no file:// locations in the library (other location types are not yet supported)
4. Show the 'organise selection' option in the menu when browsing individual library locations