### PR TITLE
E with a grave accent now behaves just like every other character

### DIFF
--- a/fileops.py
+++ b/fileops.py
@@ -90,10 +90,10 @@ class MusicFile(object):
             self.entry = db_entry
             self.rbdb_rep = ('%28', '%29', '%2B', '%27', '%2C', '%3A', '%21',
                              '%24', '%26', '%2A', '%2C', '%2D', '%2E', '%3D',
-                             '%40', '%5F', '%7E', '%C3%A8')
+                             '%40', '%5F', '%7E')
             self.rbdb_itm = ('(', ')', '+', "'", ',', ':', '!',
                              '$', '&', '*', ',', '-', '.', '=',
-                             '@', '_', '~', 'è')
+                             '@', '_', '~')
 
     def set_ascii(self, string):
         """ Change unicode codes back to ascii for RhythmDB


### PR DESCRIPTION
Not sure why this plugin explicitly un-escaped `è` from `%C3%A8` to `è` (while leaving every other non-ASCII character as-is).

If we un-escape it, the relocation works, but then Rhythmbox would store the file path with a weird `&#`-escape in rythmdb.xml. This would make Rhythmbox unable to find the file again when it restarts.